### PR TITLE
Add the new scalar value for DataType::Binary

### DIFF
--- a/rust/datafusion/src/physical_plan/array_expressions.rs
+++ b/rust/datafusion/src/physical_plan/array_expressions.rs
@@ -68,6 +68,7 @@ pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 
     match args[0].data_type() {
+        DataType::Binary => array!(args, BinaryArray, BinaryBuilder),
         DataType::Utf8 => array!(args, StringArray, StringBuilder),
         DataType::LargeUtf8 => array!(args, LargeStringArray, LargeStringBuilder),
         DataType::Boolean => array!(args, BooleanArray, BooleanBuilder),
@@ -131,6 +132,7 @@ pub static SUPPORTED_ARRAY_TYPES: &[DataType] = &[
     DataType::Int64Decimal(10),
     DataType::Float32,
     DataType::Float64,
+    DataType::Binary,
     DataType::Utf8,
     DataType::LargeUtf8,
 ];

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -644,6 +644,14 @@ mod tests {
             ScalarValue::from(1u32),
             DataType::UInt64,
             "PrimitiveArray<UInt64>\n[\n  1,\n  1,\n]",
+        )?;
+
+        // arrays of binary type
+        generic_test_array(
+            ScalarValue::Binary(Some(vec![1, 2])),
+            ScalarValue::Binary(Some(vec![3, 4])),
+            DataType::Binary,
+            "BinaryArray\n[\n  [1, 2],\n  [3, 4],\n]",
         )
     }
 }


### PR DESCRIPTION
The support is minimal to allow passing and using the type in UDFs.