### PR TITLE
Fix deprecation warning in clippy

### DIFF
--- a/rust/arrow/benches/builder.rs
+++ b/rust/arrow/benches/builder.rs
@@ -34,21 +34,21 @@ const NUM_BATCHES: usize = 64;
 
 fn bench_primitive(c: &mut Criterion) {
     let data: [i64; BATCH_SIZE] = [100; BATCH_SIZE];
-    c.bench(
-        "bench_primitive",
-        Benchmark::new("bench_primitive", move |b| {
-            b.iter(|| {
-                let mut builder = Int64Builder::new(64);
-                for _ in 0..NUM_BATCHES {
-                    let _ = black_box(builder.append_slice(&data[..]));
-                }
-                black_box(builder.finish());
-            })
+
+    let mut group = c.benchmark_group("bench_primitive");
+    group.throughput(Throughput::Bytes(
+        ((data.len() * NUM_BATCHES * size_of::<i64>()) as u32).into(),
+    ));
+    group.bench_function("bench_primitive", |b| {
+        b.iter(|| {
+            let mut builder = Int64Builder::new(64);
+            for _ in 0..NUM_BATCHES {
+                let _ = black_box(builder.append_slice(&data[..]));
+            }
+            black_box(builder.finish());
         })
-        .throughput(Throughput::Bytes(
-            ((data.len() * NUM_BATCHES * size_of::<i64>()) as u32).into(),
-        )),
-    );
+    });
+    group.finish();
 }
 
 fn bench_bool(c: &mut Criterion) {
@@ -57,21 +57,21 @@ fn bench_bool(c: &mut Criterion) {
         .take(BATCH_SIZE)
         .collect();
     let data_len = data.len();
-    c.bench(
-        "bench_bool",
-        Benchmark::new("bench_bool", move |b| {
-            b.iter(|| {
-                let mut builder = BooleanBuilder::new(64);
-                for _ in 0..NUM_BATCHES {
-                    let _ = black_box(builder.append_slice(&data[..]));
-                }
-                black_box(builder.finish());
-            })
+
+    let mut group = c.benchmark_group("bench_bool");
+    group.throughput(Throughput::Bytes(
+        ((data_len * NUM_BATCHES * size_of::<bool>()) as u32).into(),
+    ));
+    group.bench_function("bench_bool", |b| {
+        b.iter(|| {
+            let mut builder = BooleanBuilder::new(64);
+            for _ in 0..NUM_BATCHES {
+                let _ = black_box(builder.append_slice(&data[..]));
+            }
+            black_box(builder.finish());
         })
-        .throughput(Throughput::Bytes(
-            ((data_len * NUM_BATCHES * size_of::<bool>()) as u32).into(),
-        )),
-    );
+    });
+    group.finish();
 }
 
 criterion_group!(benches, bench_primitive, bench_bool);

--- a/rust/arrow/benches/csv_writer.rs
+++ b/rust/arrow/benches/csv_writer.rs
@@ -63,12 +63,7 @@ fn record_batches_to_csv() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench(
-        "record_batches_to_csv",
-        Benchmark::new("record_batches_to_csv", move |b| {
-            b.iter(record_batches_to_csv)
-        }),
-    );
+    c.bench_function("record_batches_to_csv", |b| b.iter(record_batches_to_csv));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/rust/arrow/benches/json_reader.rs
+++ b/rust/arrow/benches/json_reader.rs
@@ -100,18 +100,12 @@ fn json_list_primitive_to_record_batch() {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench(
-        "json_primitive_to_record_batch",
-        Benchmark::new("json_primitive_to_record_batch", move |b| {
-            b.iter(json_primitive_to_record_batch)
-        }),
-    );
-    c.bench(
-        "json_list_primitive_to_record_batch",
-        Benchmark::new("json_list_primitive_to_record_batch", move |b| {
-            b.iter(json_list_primitive_to_record_batch)
-        }),
-    );
+    c.bench_function("json_primitive_to_record_batch", |b| {
+        b.iter(json_primitive_to_record_batch)
+    });
+    c.bench_function("json_list_primitive_to_record_batch", |b| {
+        b.iter(json_list_primitive_to_record_batch)
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
It's a cherrypick of the corresponding commit in the upstream repository.