### PR TITLE
Do not run some github actions in the fork

### DIFF
--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -48,7 +48,9 @@ jobs:
             script({github, context});
 
       - name: Check title
+        # Our fork does not require PRs to go through the JIRA.
         if: |
+          false &&
           github.event_name == 'pull_request_target' &&
             (github.event.action == 'opened' ||
              github.event.action == 'edited')

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,6 +191,8 @@ jobs:
           cargo test
 
   clippy:
+    # We choose not to run clippy in our fork.
+    if: false 
     name: Clippy
     needs: [linux-build-lib]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This disables:
  - checking the PR title contains a JIRA issue,
  - running clippy on top of the rust code.