### PR TITLE
[Datafusion] NOW() function support (#288)

### DIFF
--- a/datafusion/src/optimizer/eliminate_limit.rs
+++ b/datafusion/src/optimizer/eliminate_limit.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimizer rule to replace `LIMIT 0` on a plan with an empty relation.
+//! This saves time in planning and executing the query.
+use crate::error::Result;
+use crate::logical_plan::LogicalPlan;
+use crate::optimizer::optimizer::OptimizerRule;
+
+use super::utils;
+use crate::execution::context::ExecutionProps;
+
+/// Optimization rule that replaces LIMIT 0 with an [LogicalPlan::EmptyRelation]
+pub struct EliminateLimit;
+
+impl EliminateLimit {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for EliminateLimit {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
+        match plan {
+            LogicalPlan::Limit { n, input } if *n == 0 => {
+                Ok(LogicalPlan::EmptyRelation {
+                    produce_one_row: false,
+                    schema: input.schema().clone(),
+                })
+            }
+            // Rest: recurse and find possible LIMIT 0 nodes
+            _ => {
+                let expr = plan.expressions();
+
+                // apply the optimization to all inputs of the plan
+                let inputs = plan.inputs();
+                let new_inputs = inputs
+                    .iter()
+                    .map(|plan| self.optimize(plan, execution_props))
+                    .collect::<Result<Vec<_>>>()?;
+
+                utils::from_plan(plan, &expr, &new_inputs)
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "eliminate_limit"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logical_plan::LogicalPlanBuilder;
+    use crate::logical_plan::{col, sum};
+    use crate::test::*;
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let rule = EliminateLimit::new();
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+        assert_eq!(plan.schema(), optimized_plan.schema());
+    }
+
+    #[test]
+    fn limit_0_root() {
+        let table_scan = test_table_scan().unwrap();
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .limit(0)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        // No aggregate / scan / limit
+        let expected = "EmptyRelation";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+
+    #[test]
+    fn limit_0_nested() {
+        let table_scan = test_table_scan().unwrap();
+        let plan1 = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .build()
+            .unwrap();
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![col("a")], vec![sum(col("b"))])
+            .unwrap()
+            .limit(0)
+            .unwrap()
+            .union(plan1)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        // Left side is removed
+        let expected = "Union\
+            \n  EmptyRelation\
+            \n  Aggregate: groupBy=[[#a]], aggr=[[SUM(#b)]]\
+            \n    TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+    }
+}

--- a/rust/ballista/rust/core/src/serde/physical_plan/from_proto.rs
+++ b/rust/ballista/rust/core/src/serde/physical_plan/from_proto.rs
@@ -33,7 +33,9 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use datafusion::catalog::catalog::{
     CatalogList, CatalogProvider, MemoryCatalogList, MemoryCatalogProvider,
 };
-use datafusion::execution::context::{ExecutionConfig, ExecutionContextState};
+use datafusion::execution::context::{
+    ExecutionConfig, ExecutionContextState, ExecutionProps,
+};
 use datafusion::logical_plan::{DFSchema, Expr};
 use datafusion::physical_plan::aggregates::{create_aggregate_expr, AggregateFunction};
 use datafusion::physical_plan::expressions::col;
@@ -226,6 +228,7 @@ impl TryInto<Arc<dyn ExecutionPlan>> for &protobuf::PhysicalPlanNode {
                     var_provider: Default::default(),
                     aggregate_functions: Default::default(),
                     config: ExecutionConfig::new(),
+                    execution_props: ExecutionProps::new(),
                 };
 
                 let input_schema = hash_agg
@@ -390,6 +393,7 @@ fn compile_expr(
         var_provider: HashMap::new(),
         aggregate_functions: HashMap::new(),
         config: ExecutionConfig::new(),
+        execution_props: ExecutionProps::new(),
     };
     let expr: Expr = expr.try_into()?;
     df_planner

--- a/rust/datafusion/src/cube_ext/joinagg.rs
+++ b/rust/datafusion/src/cube_ext/joinagg.rs
@@ -19,7 +19,7 @@
 use crate::cube_ext::join::{left_cross_join, plan_cross_join, CrossJoin, CrossJoinExec};
 use crate::cube_ext::stream::StreamWithSchema;
 use crate::error::Result;
-use crate::execution::context::ExecutionContextState;
+use crate::execution::context::{ExecutionContextState, ExecutionProps};
 use crate::logical_plan::{DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils::from_plan;
@@ -92,11 +92,11 @@ impl UserDefinedLogicalNode for CrossJoinAgg {
 
 pub struct FoldCrossJoinAggregate;
 impl OptimizerRule for FoldCrossJoinAggregate {
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(&self, plan: &LogicalPlan, execution_props: &ExecutionProps) -> Result<LogicalPlan> {
         let inputs = plan
             .inputs()
             .into_iter()
-            .map(|i| self.optimize(i))
+            .map(|i| self.optimize(i, execution_props))
             .collect::<Result<Vec<_>>>()?;
         let exprs = plan.expressions();
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -72,6 +72,7 @@ use crate::sql::{
 };
 use crate::variable::{VarProvider, VarType};
 use crate::{dataframe::DataFrame, physical_plan::udaf::AggregateUDF};
+use chrono::{DateTime, Utc};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 
@@ -157,6 +158,7 @@ impl ExecutionContext {
                 var_provider: HashMap::new(),
                 aggregate_functions: HashMap::new(),
                 config,
+                execution_props: ExecutionProps::new(),
             })),
         }
     }
@@ -454,12 +456,16 @@ impl ExecutionContext {
 
     /// Optimizes the logical plan by applying optimizer rules.
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
-        let optimizers = &self.state.lock().unwrap().config.optimizers;
+        let state = &mut self.state.lock().unwrap();
+        let execution_props = &mut state.execution_props.clone();
+        let optimizers = &state.config.optimizers;
+
+        let execution_props = execution_props.start_execution();
 
         let mut new_plan = plan.clone();
         debug!("Logical plan:\n {:?}", plan);
         for optimizer in optimizers {
-            new_plan = optimizer.optimize(&new_plan)?;
+            new_plan = optimizer.optimize(&new_plan, execution_props)?;
         }
         debug!("Optimized logical plan:\n {:?}", new_plan);
         Ok(new_plan)
@@ -470,7 +476,9 @@ impl ExecutionContext {
         &self,
         logical_plan: &LogicalPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let state = self.state.lock().unwrap();
+        let mut state = self.state.lock().unwrap();
+        state.execution_props.start_execution();
+
         state
             .config
             .query_planner
@@ -741,6 +749,15 @@ impl ExecutionConfig {
     }
 }
 
+/// Holds per-execution properties and data (such as starting timestamps, etc).
+/// An instance of this struct is created each time a [`LogicalPlan`] is prepared for
+/// execution (optimized). If the same plan is optimized multiple times, a new
+/// `ExecutionProps` is created each time.
+#[derive(Clone)]
+pub struct ExecutionProps {
+    pub(crate) query_execution_start_time: DateTime<Utc>,
+}
+
 /// Execution context for registering data sources and executing queries
 #[derive(Clone)]
 pub struct ExecutionContextState {
@@ -754,9 +771,38 @@ pub struct ExecutionContextState {
     pub aggregate_functions: HashMap<String, Arc<AggregateUDF>>,
     /// Context configuration
     pub config: ExecutionConfig,
+    /// Execution properties
+    pub execution_props: ExecutionProps,
+}
+
+impl ExecutionProps {
+    /// Creates a new execution props
+    pub fn new() -> Self {
+        ExecutionProps {
+            query_execution_start_time: chrono::Utc::now(),
+        }
+    }
+
+    /// Marks the execution of query started timestamp
+    pub fn start_execution(&mut self) -> &Self {
+        self.query_execution_start_time = chrono::Utc::now();
+        &*self
+    }
 }
 
 impl ExecutionContextState {
+    /// Returns new ExecutionContextState
+    pub fn new() -> Self {
+        ExecutionContextState {
+            catalog_list: Arc::new(MemoryCatalogList::new()),
+            scalar_functions: HashMap::new(),
+            var_provider: HashMap::new(),
+            aggregate_functions: HashMap::new(),
+            config: ExecutionConfig::new(),
+            execution_props: ExecutionProps::new(),
+        }
+    }
+
     fn resolve_table_ref<'a>(
         &'a self,
         table_ref: impl Into<TableReference<'a>>,
@@ -1516,7 +1562,7 @@ mod tests {
             "+-------------------------+-------------------------+-------------------------+---------------------+",
             "| 2021-01-01 05:11:10.432 | 2021-01-01 05:11:10.432 | 2021-01-01 05:11:10.432 | 2021-01-01 05:11:10 |",
             "+-------------------------+-------------------------+-------------------------+---------------------+",
-];
+        ];
         assert_batches_sorted_eq!(expected, &results);
 
         Ok(())
@@ -1642,7 +1688,7 @@ mod tests {
 
         let results = plan_and_collect(
             &mut ctx,
-            "SELECT date_trunc('week', t1) as week, SUM(c2) FROM test GROUP BY date_trunc('week', t1)"
+            "SELECT date_trunc('week', t1) as week, SUM(c2) FROM test GROUP BY date_trunc('week', t1)",
         ).await?;
         assert_eq!(results.len(), 1);
 
@@ -1820,16 +1866,15 @@ mod tests {
         let results = run_count_distinct_integers_aggregated_scenario(partitions).await?;
         assert_eq!(results.len(), 1);
 
-        let expected = vec!
-[
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-    "| c_group | COUNT(c_uint64) | COUNT(DISTINCT c_int8) | COUNT(DISTINCT c_int16) | COUNT(DISTINCT c_int32) | COUNT(DISTINCT c_int64) | COUNT(DISTINCT c_uint8) | COUNT(DISTINCT c_uint16) | COUNT(DISTINCT c_uint32) | COUNT(DISTINCT c_uint64) |",
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-    "| a       | 3               | 2                      | 2                       | 2                       | 2                       | 2                       | 2                        | 2                        | 2                        |",
-    "| b       | 1               | 1                      | 1                       | 1                       | 1                       | 1                       | 1                        | 1                        | 1                        |",
-    "| c       | 3               | 2                      | 2                       | 2                       | 2                       | 2                       | 2                        | 2                        | 2                        |",
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-];
+        let expected = vec![
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+            "| c_group | COUNT(c_uint64) | COUNT(DISTINCT c_int8) | COUNT(DISTINCT c_int16) | COUNT(DISTINCT c_int32) | COUNT(DISTINCT c_int64) | COUNT(DISTINCT c_uint8) | COUNT(DISTINCT c_uint16) | COUNT(DISTINCT c_uint32) | COUNT(DISTINCT c_uint64) |",
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+            "| a       | 3               | 2                      | 2                       | 2                       | 2                       | 2                       | 2                        | 2                        | 2                        |",
+            "| b       | 1               | 1                      | 1                       | 1                       | 1                       | 1                       | 1                        | 1                        | 1                        |",
+            "| c       | 3               | 2                      | 2                       | 2                       | 2                       | 2                       | 2                        | 2                        | 2                        |",
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+        ];
         assert_batches_sorted_eq!(expected, &results);
 
         Ok(())
@@ -1849,14 +1894,14 @@ mod tests {
         assert_eq!(results.len(), 1);
 
         let expected = vec![
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-    "| c_group | COUNT(c_uint64) | COUNT(DISTINCT c_int8) | COUNT(DISTINCT c_int16) | COUNT(DISTINCT c_int32) | COUNT(DISTINCT c_int64) | COUNT(DISTINCT c_uint8) | COUNT(DISTINCT c_uint16) | COUNT(DISTINCT c_uint32) | COUNT(DISTINCT c_uint64) |",
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-    "| a       | 5               | 3                      | 3                       | 3                       | 3                       | 3                       | 3                        | 3                        | 3                        |",
-    "| b       | 5               | 4                      | 4                       | 4                       | 4                       | 4                       | 4                        | 4                        | 4                        |",
-    "| c       | 1               | 1                      | 1                       | 1                       | 1                       | 1                       | 1                        | 1                        | 1                        |",
-    "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
-];
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+            "| c_group | COUNT(c_uint64) | COUNT(DISTINCT c_int8) | COUNT(DISTINCT c_int16) | COUNT(DISTINCT c_int32) | COUNT(DISTINCT c_int64) | COUNT(DISTINCT c_uint8) | COUNT(DISTINCT c_uint16) | COUNT(DISTINCT c_uint32) | COUNT(DISTINCT c_uint64) |",
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+            "| a       | 5               | 3                      | 3                       | 3                       | 3                       | 3                       | 3                        | 3                        | 3                        |",
+            "| b       | 5               | 4                      | 4                       | 4                       | 4                       | 4                       | 4                        | 4                        | 4                        |",
+            "| c       | 1               | 1                      | 1                       | 1                       | 1                       | 1                       | 1                        | 1                        | 1                        |",
+            "+---------+-----------------+------------------------+-------------------------+-------------------------+-------------------------+-------------------------+--------------------------+--------------------------+--------------------------+",
+        ];
         assert_batches_sorted_eq!(expected, &results);
 
         Ok(())
@@ -2250,6 +2295,7 @@ mod tests {
         }
         Ok(())
     }
+
     #[test]
     fn ctx_sql_should_optimize_plan() -> Result<()> {
         let mut ctx = ExecutionContext::new();
@@ -2721,13 +2767,11 @@ mod tests {
             .await
             .unwrap();
         let expected = vec![
-
-    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| table_catalog | table_schema | table_name | column_name | ordinal_position | column_default | is_nullable | data_type | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
-    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| datafusion    | public       | t          | i           | 0                |                | YES         | Int32     |                          |                        | 32                | 2                       |               |                    |               |",
-    "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-
+            "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+            "| table_catalog | table_schema | table_name | column_name | ordinal_position | column_default | is_nullable | data_type | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
+            "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+            "| datafusion    | public       | t          | i           | 0                |                | YES         | Int32     |                          |                        | 32                | 2                       |               |                    |               |",
+            "+---------------+--------------+------------+-------------+------------------+----------------+-------------+-----------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
         ];
         assert_batches_sorted_eq!(expected, &result);
 
@@ -2861,18 +2905,18 @@ mod tests {
                 .unwrap();
 
         let expected = vec![
-    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| table_catalog | table_schema | table_name | column_name      | ordinal_position | column_default | is_nullable | data_type                   | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
-    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
-    "| my_catalog    | my_schema    | t1         | i                | 0                |                | YES         | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | binary_col       | 4                |                | NO          | Binary                      |                          | 2147483647             |                   |                         |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | float64_col      | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | int32_col        | 0                |                | NO          | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | large_binary_col | 5                |                | NO          | LargeBinary                 |                          | 9223372036854775807    |                   |                         |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | large_utf8_col   | 3                |                | NO          | LargeUtf8                   |                          | 9223372036854775807    |                   |                         |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | timestamp_nanos  | 6                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
-    "| my_catalog    | my_schema    | t2         | utf8_col         | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
-    "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+            "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+            "| table_catalog | table_schema | table_name | column_name      | ordinal_position | column_default | is_nullable | data_type                   | character_maximum_length | character_octet_length | numeric_precision | numeric_precision_radix | numeric_scale | datetime_precision | interval_type |",
+            "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
+            "| my_catalog    | my_schema    | t1         | i                | 0                |                | YES         | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | binary_col       | 4                |                | NO          | Binary                      |                          | 2147483647             |                   |                         |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | float64_col      | 1                |                | YES         | Float64                     |                          |                        | 24                | 2                       |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | int32_col        | 0                |                | NO          | Int32                       |                          |                        | 32                | 2                       |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | large_binary_col | 5                |                | NO          | LargeBinary                 |                          | 9223372036854775807    |                   |                         |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | large_utf8_col   | 3                |                | NO          | LargeUtf8                   |                          | 9223372036854775807    |                   |                         |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | timestamp_nanos  | 6                |                | NO          | Timestamp(Nanosecond, None) |                          |                        |                   |                         |               |                    |               |",
+            "| my_catalog    | my_schema    | t2         | utf8_col         | 2                |                | YES         | Utf8                        |                          | 2147483647             |                   |                         |               |                    |               |",
+            "+---------------+--------------+------------+------------------+------------------+----------------+-------------+-----------------------------+--------------------------+------------------------+-------------------+-------------------------+---------------+--------------------+---------------+",
         ];
         assert_batches_sorted_eq!(expected, &result);
     }

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -16,8 +16,8 @@
 
 use crate::datasource::datasource::TableProviderFilterPushDown;
 use crate::error::DataFusionError;
-use crate::logical_plan::{and, JoinType, LogicalPlan};
-use crate::logical_plan::{DFSchema, Expr};
+use crate::logical_plan::{and, JoinType, LogicalPlan, DFSchema, Expr};
+use crate::execution::context::ExecutionProps;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
 use crate::physical_plan::expressions::Column;
@@ -544,7 +544,7 @@ impl OptimizerRule for FilterPushDown {
         "filter_push_down"
     }
 
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(&self, plan: &LogicalPlan, _: &ExecutionProps) -> Result<LogicalPlan> {
         optimize(plan, State::default())
     }
 }
@@ -589,7 +589,9 @@ mod tests {
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = FilterPushDown::new();
-        let optimized_plan = rule.optimize(plan).expect("failed to optimize plan");
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);
     }

--- a/rust/datafusion/src/optimizer/hash_build_probe_order.rs
+++ b/rust/datafusion/src/optimizer/hash_build_probe_order.rs
@@ -27,6 +27,7 @@ use crate::optimizer::optimizer::OptimizerRule;
 use crate::{error::Result, prelude::JoinType};
 
 use super::utils;
+use crate::execution::context::ExecutionProps;
 
 /// BuildProbeOrder reorders the build and probe phase of
 /// hash joins. This uses the amount of rows that a datasource has.
@@ -106,7 +107,11 @@ impl OptimizerRule for HashBuildProbeOrder {
         "hash_build_probe_order"
     }
 
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
         match plan {
             // Main optimization rule, swaps order of left and right
             // based on number of rows in each table
@@ -117,8 +122,8 @@ impl OptimizerRule for HashBuildProbeOrder {
                 join_type,
                 schema,
             } => {
-                let left = self.optimize(left)?;
-                let right = self.optimize(right)?;
+                let left = self.optimize(left, execution_props)?;
+                let right = self.optimize(right, execution_props)?;
                 if should_swap_join_order(&left, &right) {
                     // Swap left and right, change join type and (equi-)join key order
                     Ok(LogicalPlan::Join {
@@ -162,7 +167,7 @@ impl OptimizerRule for HashBuildProbeOrder {
                 let inputs = plan.inputs();
                 let new_inputs = inputs
                     .iter()
-                    .map(|plan| self.optimize(plan))
+                    .map(|plan| self.optimize(plan, execution_props))
                     .collect::<Result<Vec<_>>>()?;
 
                 utils::from_plan(plan, &expr, &new_inputs)

--- a/rust/datafusion/src/optimizer/limit_push_down.rs
+++ b/rust/datafusion/src/optimizer/limit_push_down.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 
 use super::utils;
 use crate::error::Result;
+use crate::execution::context::ExecutionProps;
 use crate::logical_plan::LogicalPlan;
 use crate::optimizer::optimizer::OptimizerRule;
 
@@ -127,7 +128,7 @@ fn limit_push_down(
 }
 
 impl OptimizerRule for LimitPushDown {
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(&self, plan: &LogicalPlan, _: &ExecutionProps) -> Result<LogicalPlan> {
         limit_push_down(None, plan)
     }
 
@@ -145,7 +146,9 @@ mod test {
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
         let rule = LimitPushDown::new();
-        let optimized_plan = rule.optimize(plan).expect("failed to optimize plan");
+        let optimized_plan = rule
+            .optimize(plan, &ExecutionProps::new())
+            .expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);
     }

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -18,6 +18,7 @@
 //! Query optimizer traits
 
 use crate::error::Result;
+use crate::execution::context::ExecutionProps;
 use crate::logical_plan::LogicalPlan;
 
 /// `OptimizerRule` transforms one ['LogicalPlan'] into another which
@@ -25,7 +26,11 @@ use crate::logical_plan::LogicalPlan;
 /// way.
 pub trait OptimizerRule {
     /// Rewrite `plan` to an optimized form
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan>;
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan>;
 
     /// A human readable name for this optimizer rule
     fn name(&self) -> &str;

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -20,6 +20,7 @@
 
 use crate::cube_ext::alias::LogicalAlias;
 use crate::error::Result;
+use crate::execution::context::ExecutionProps;
 use crate::logical_plan::{DFField, DFSchema, DFSchemaRef, LogicalPlan, ToDFSchema};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
@@ -32,7 +33,11 @@ use utils::optimize_explain;
 pub struct ProjectionPushDown {}
 
 impl OptimizerRule for ProjectionPushDown {
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
         // set of all columns refered by the plan (and thus considered required by the root)
         let required_columns = plan
             .schema()
@@ -40,7 +45,7 @@ impl OptimizerRule for ProjectionPushDown {
             .iter()
             .map(|f| f.name().clone())
             .collect::<HashSet<String>>();
-        optimize_plan(self, plan, &required_columns, false)
+        optimize_plan(self, plan, &required_columns, false, execution_props)
     }
 
     fn name(&self) -> &str {
@@ -106,6 +111,7 @@ fn optimize_plan(
     plan: &LogicalPlan,
     required_columns: &HashSet<String>, // set of columns required up to this step
     has_projection: bool,
+    execution_props: &ExecutionProps,
 ) -> Result<LogicalPlan> {
     let mut new_required_columns = required_columns.clone();
     match plan {
@@ -138,8 +144,13 @@ fn optimize_plan(
                     }
                 })?;
 
-            let new_input =
-                optimize_plan(optimizer, &input, &new_required_columns, true)?;
+            let new_input = optimize_plan(
+                optimizer,
+                &input,
+                &new_required_columns,
+                true,
+                execution_props,
+            )?;
             if new_fields.is_empty() {
                 // no need for an expression at all
                 Ok(new_input)
@@ -168,12 +179,14 @@ fn optimize_plan(
                     &left,
                     &new_required_columns,
                     true,
+                    execution_props,
                 )?),
                 right: Arc::new(optimize_plan(
                     optimizer,
                     &right,
                     &new_required_columns,
                     true,
+                    execution_props,
                 )?),
 
                 join_type: *join_type,
@@ -227,6 +240,7 @@ fn optimize_plan(
                     &input,
                     &new_required_columns,
                     true,
+                    execution_props,
                 )?),
                 schema: DFSchemaRef::new(new_schema),
             })
@@ -268,7 +282,14 @@ fn optimize_plan(
             schema,
         } => {
             let schema = schema.as_ref().to_owned().into();
-            optimize_explain(optimizer, *verbose, &*plan, stringified_plans, &schema)
+            optimize_explain(
+                optimizer,
+                *verbose,
+                &*plan,
+                stringified_plans,
+                &schema,
+                execution_props,
+            )
         }
         // all other nodes: Add any additional columns used by
         // expressions in this node to the list of required columns
@@ -300,7 +321,13 @@ fn optimize_plan(
             let new_inputs = inputs
                 .iter()
                 .map(|plan| {
-                    optimize_plan(optimizer, plan, &new_required_columns, has_projection)
+                    optimize_plan(
+                        optimizer,
+                        plan,
+                        &new_required_columns,
+                        has_projection,
+                        execution_props,
+                    )
                 })
                 .collect::<Result<Vec<_>>>()?;
 
@@ -318,6 +345,7 @@ fn optimize_plan(
                         plan,
                         &unalias_required_columns(original_schema, &new_required_columns),
                         has_projection,
+                        execution_props,
                     )
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -592,6 +620,6 @@ mod tests {
 
     fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
         let rule = ProjectionPushDown::new();
-        rule.optimize(plan)
+        rule.optimize(plan, &ExecutionProps::new())
     }
 }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -22,6 +22,7 @@ use std::{collections::HashSet, sync::Arc};
 use arrow::datatypes::Schema;
 
 use super::optimizer::OptimizerRule;
+use crate::execution::context::ExecutionProps;
 use crate::logical_plan::{
     Expr, LogicalPlan, Operator, Partitioning, PlanType, Recursion, StringifiedPlan,
     ToDFSchema,
@@ -103,11 +104,12 @@ pub fn optimize_explain(
     plan: &LogicalPlan,
     stringified_plans: &[StringifiedPlan],
     schema: &Schema,
+    execution_props: &ExecutionProps,
 ) -> Result<LogicalPlan> {
     // These are the fields of LogicalPlan::Explain It might be nice
     // to transform that enum Variant into its own struct and avoid
     // passing the fields individually
-    let plan = Arc::new(optimizer.optimize(plan)?);
+    let plan = Arc::new(optimizer.optimize(plan, execution_props)?);
     let mut stringified_plans = stringified_plans.to_vec();
     let optimizer_name = optimizer.name().into();
     stringified_plans.push(StringifiedPlan::new(
@@ -130,6 +132,7 @@ pub fn optimize_explain(
 pub fn optimize_children(
     optimizer: &impl OptimizerRule,
     plan: &LogicalPlan,
+    execution_props: &ExecutionProps,
 ) -> Result<LogicalPlan> {
     if let LogicalPlan::Explain {
         verbose,
@@ -144,6 +147,7 @@ pub fn optimize_children(
             &*plan,
             stringified_plans,
             &schema.as_ref().to_owned().into(),
+            execution_props,
         );
     }
 
@@ -151,7 +155,7 @@ pub fn optimize_children(
     let new_inputs = plan
         .inputs()
         .into_iter()
-        .map(|plan| optimizer.optimize(plan))
+        .map(|plan| optimizer.optimize(plan, execution_props))
         .collect::<Result<Vec<_>>>()?;
 
     from_plan(plan, &new_exprs, &new_inputs)
@@ -444,7 +448,11 @@ mod tests {
     struct TestOptimizer {}
 
     impl OptimizerRule for TestOptimizer {
-        fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+        fn optimize(
+            &self,
+            plan: &LogicalPlan,
+            _: &ExecutionProps,
+        ) -> Result<LogicalPlan> {
             Ok(plan.clone())
         }
 
@@ -466,6 +474,7 @@ mod tests {
             &empty_plan,
             &[StringifiedPlan::new(PlanType::LogicalPlan, "...")],
             schema.as_ref(),
+            &ExecutionProps::new(),
         )?;
 
         match &optimized_explain {

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -449,6 +449,23 @@ pub fn to_timestamp(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     )
 }
 
+/// Create an implementation of `now()` that always returns the
+/// specified timestamp.
+///
+/// The semantics of `now()` require it to return the same value
+/// whenever it is called in a query. This this value is chosen during
+/// planning time and bound into a closure that
+pub fn make_now(
+    now_ts: DateTime<Utc>,
+) -> impl Fn(&[ColumnarValue]) -> Result<ColumnarValue> {
+    let now_ts = Some(now_ts.timestamp_nanos());
+    move |_arg| {
+        Ok(ColumnarValue::Scalar(ScalarValue::TimestampNanosecond(
+            now_ts,
+        )))
+    }
+}
+
 fn date_trunc_single(granularity: &str, value: i64) -> Result<i64> {
     let value = timestamp_ns_to_datetime(value).with_nanosecond(0);
     let value = match granularity {
@@ -481,7 +498,7 @@ fn date_trunc_single(granularity: &str, value: i64) -> Result<i64> {
             return Err(DataFusionError::Execution(format!(
                 "Unsupported date_trunc granularity: {}",
                 unsupported
-            )))
+            )));
         }
     };
     // `with_x(0)` are infalible because `0` are always a valid

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -34,6 +34,7 @@ use super::{
     ColumnarValue, PhysicalExpr,
 };
 use crate::logical_plan::DFSchema;
+use crate::execution::context::ExecutionContextState;
 use crate::physical_plan::array_expressions;
 use crate::physical_plan::datetime_expressions;
 use crate::physical_plan::expressions::{nullif_func, SUPPORTED_NULLIF_TYPES};
@@ -196,6 +197,8 @@ pub enum BuiltinScalarFunction {
     ToHex,
     /// to_timestamp
     ToTimestamp,
+    ///now
+    Now,
     /// translate
     Translate,
     /// trim
@@ -275,6 +278,7 @@ impl FromStr for BuiltinScalarFunction {
             "substr" => BuiltinScalarFunction::Substr,
             "to_hex" => BuiltinScalarFunction::ToHex,
             "to_timestamp" => BuiltinScalarFunction::ToTimestamp,
+            "now" => BuiltinScalarFunction::Now,
             "translate" => BuiltinScalarFunction::Translate,
             "trim" => BuiltinScalarFunction::Trim,
             "upper" => BuiltinScalarFunction::Upper,
@@ -299,15 +303,6 @@ pub fn return_type(
 
     // verify that this is a valid set of data types for this function
     data_types(&arg_types, &signature(fun))?;
-
-    if arg_types.is_empty() {
-        // functions currently cannot be evaluated without arguments, as they can't
-        // know the number of rows to return.
-        return Err(DataFusionError::Plan(format!(
-            "Function '{}' requires at least one argument",
-            fun
-        )));
-    }
 
     // the return type of the built in function.
     // Some built-in functions' return type depends on the incoming type.
@@ -587,6 +582,7 @@ pub fn return_type(
         BuiltinScalarFunction::ToTimestamp => {
             Ok(DataType::Timestamp(TimeUnit::Nanosecond, None))
         }
+        BuiltinScalarFunction::Now => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         BuiltinScalarFunction::Translate => Ok(match arg_types[0] {
             DataType::LargeUtf8 => DataType::LargeUtf8,
             DataType::Utf8 => DataType::Utf8,
@@ -718,6 +714,7 @@ pub fn create_physical_expr(
     fun: &BuiltinScalarFunction,
     args: &[Arc<dyn PhysicalExpr>],
     input_schema: &DFSchema,
+    ctx_state: &ExecutionContextState,
 ) -> Result<Arc<dyn PhysicalExpr>> {
     let fun_expr: ScalarFunctionImplementation = Arc::new(match fun {
         // math functions
@@ -811,6 +808,22 @@ pub fn create_physical_expr(
         }
         BuiltinScalarFunction::DatePart => datetime_expressions::date_part,
         BuiltinScalarFunction::DateTrunc => datetime_expressions::date_trunc,
+        BuiltinScalarFunction::Now => {
+            // bind value for now at plan time
+            let fun_expr = Arc::new(datetime_expressions::make_now(
+                ctx_state.execution_props.query_execution_start_time,
+            ));
+
+            // TODO refactor code to not return here, but instead fall through below
+            let args = vec![];
+            let arg_types = vec![]; // has no args
+            return Ok(Arc::new(ScalarFunctionExpr::new(
+                &format!("{}", fun),
+                fun_expr,
+                args,
+                &return_type(&fun, &arg_types)?,
+            )));
+        }
         BuiltinScalarFunction::InitCap => |args| match args[0].data_type() {
             DataType::Utf8 => {
                 make_scalar_function(string_expressions::initcap::<i32>)(args)
@@ -1463,6 +1476,7 @@ mod tests {
         ($FUNC:ident, $ARGS:expr, $EXPECTED:expr, $EXPECTED_TYPE:ty, $DATA_TYPE: ident, $ARRAY_TYPE:ident) => {
             // used to provide type annotation
             let expected: Result<Option<$EXPECTED_TYPE>> = $EXPECTED;
+            let ctx_state = ExecutionContextState::new();
 
             // any type works here: we evaluate against a literal of `value`
             let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
@@ -1470,7 +1484,7 @@ mod tests {
             let columns: Vec<ArrayRef> = vec![Arc::new(Int32Array::from(vec![1]))];
 
             let expr =
-                create_physical_expr(&BuiltinScalarFunction::$FUNC, $ARGS, &dfschema)?;
+                create_physical_expr(&BuiltinScalarFunction::$FUNC, $ARGS, &dfschema, &ctx_state)?;
 
             // type is correct
             assert_eq!(expr.data_type(&dfschema)?, DataType::$DATA_TYPE);
@@ -3631,7 +3645,21 @@ mod tests {
 
     #[test]
     fn test_concat_error() -> Result<()> {
-        let result = return_type(&BuiltinScalarFunction::Concat, &[]);
+        let ctx_state = ExecutionContextState::new();
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let dfschema = schema.clone().to_dfschema().unwrap();
+
+        let expr = create_physical_expr(
+            &BuiltinScalarFunction::Concat,
+            &[],
+            &dfschema,
+            &ctx_state,
+        )?;
+
+        let columns: Vec<ArrayRef> = vec![Arc::new(Int32Array::from(vec![1]))];
+        let batch = RecordBatch::try_new(Arc::new(schema.clone()), columns)?;
+        let result = expr.evaluate(&batch);
+
         if result.is_ok() {
             Err(DataFusionError::Plan(
                 "Function 'concat' cannot accept zero arguments".to_string(),
@@ -3653,11 +3681,13 @@ mod tests {
             Field::new("b", value2.data_type().clone(), false),
         ]);
         let columns: Vec<ArrayRef> = vec![value1, value2];
+        let ctx_state = ExecutionContextState::new();
 
         let expr = create_physical_expr(
             &BuiltinScalarFunction::Array,
             &[col("a"), col("b")],
             &schema.clone().to_dfschema()?,
+            &ctx_state,
         )?;
 
         // type is correct
@@ -3724,6 +3754,7 @@ mod tests {
     fn test_regexp_match() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
         let dfschema = schema.clone().to_dfschema().unwrap();
+        let ctx_state = ExecutionContextState::new();
 
         // concat(value, value)
         let col_value: ArrayRef = Arc::new(StringArray::from(vec!["aaa-555"]));
@@ -3733,6 +3764,7 @@ mod tests {
             &BuiltinScalarFunction::RegexpMatch,
             &[col("a"), pattern],
             &dfschema,
+            &ctx_state,
         )?;
 
         // type is correct
@@ -3762,6 +3794,7 @@ mod tests {
     fn test_regexp_match_all_literals() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
         let dfschema = schema.clone().to_dfschema().unwrap();
+        let ctx_state = ExecutionContextState::new();
 
         // concat(value, value)
         let col_value = lit(ScalarValue::Utf8(Some("aaa-555".to_string())));
@@ -3771,6 +3804,7 @@ mod tests {
             &BuiltinScalarFunction::RegexpMatch,
             &[col_value, pattern],
             &dfschema,
+            &ctx_state,
         )?;
 
         // type is correct

--- a/rust/datafusion/src/physical_plan/parquet.rs
+++ b/rust/datafusion/src/physical_plan/parquet.rs
@@ -21,25 +21,18 @@ use std::fmt;
 use std::fs::File;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::{
-    any::Any,
-    collections::{HashMap, HashSet},
-};
+use std::{any::Any, collections::HashSet};
 
 use super::{
     planner::DefaultPhysicalPlanner, ColumnarValue, PhysicalExpr, RecordBatchStream,
     SendableRecordBatchStream,
 };
-use crate::{
-    catalog::catalog::MemoryCatalogList,
-    physical_plan::{common, ExecutionPlan, Partitioning},
-};
+use crate::physical_plan::{common, ExecutionPlan, Partitioning};
 use crate::{
     error::{DataFusionError, Result},
     execution::context::ExecutionContextState,
     logical_plan::{Expr, Operator},
     optimizer::utils,
-    prelude::ExecutionConfig,
 };
 use arrow::record_batch::RecordBatch;
 use arrow::{
@@ -395,13 +388,7 @@ impl RowGroupPredicateBuilder {
             .map(|(_, _, f)| f.clone())
             .collect::<Vec<_>>();
         let stat_schema = Schema::new(stat_fields);
-        let execution_context_state = ExecutionContextState {
-            catalog_list: Arc::new(MemoryCatalogList::new()),
-            scalar_functions: HashMap::new(),
-            var_provider: HashMap::new(),
-            aggregate_functions: HashMap::new(),
-            config: ExecutionConfig::new(),
-        };
+        let execution_context_state = ExecutionContextState::new();
         let predicate_expr = DefaultPhysicalPlanner::default().create_physical_expr(
             &logical_predicate_expr,
             &stat_schema.to_dfschema()?,

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -747,9 +747,11 @@ impl DefaultPhysicalPlanner {
                     .iter()
                     .map(|e| self.create_physical_expr(e, input_schema, ctx_state))
                     .collect::<Result<Vec<_>>>()?;
-                self.evaluate_constants(
-                    functions::create_physical_expr(fun, &physical_args, input_schema)?,
-                    physical_args,
+                functions::create_physical_expr(
+                    fun,
+                    &physical_args,
+                    input_schema,
+                    ctx_state,
                 )
             }
             Expr::ScalarUDF { fun, args } => {
@@ -1023,30 +1025,21 @@ fn tuple_err<T, R>(value: (Result<T>, Result<R>)) -> Result<(T, R)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::logical_plan::{DFField, DFSchema, DFSchemaRef, ToDFSchema};
     use crate::physical_plan::{csv::CsvReadOptions, expressions, Partitioning};
-    use crate::prelude::ExecutionConfig;
     use crate::scalar::ScalarValue;
-    use crate::{
-        catalog::catalog::MemoryCatalogList,
-        logical_plan::{DFField, DFSchema, DFSchemaRef, ToDFSchema},
-    };
     use crate::{
         logical_plan::{col, lit, sum, LogicalPlanBuilder},
         physical_plan::SendableRecordBatchStream,
     };
+    
     use arrow::datatypes::{DataType, Field, Schema};
     use async_trait::async_trait;
     use fmt::Debug;
-    use std::{any::Any, collections::HashMap, fmt};
+    use std::{any::Any, fmt};
 
     fn make_ctx_state() -> ExecutionContextState {
-        ExecutionContextState {
-            catalog_list: Arc::new(MemoryCatalogList::new()),
-            scalar_functions: HashMap::new(),
-            var_provider: HashMap::new(),
-            aggregate_functions: HashMap::new(),
-            config: ExecutionConfig::new(),
-        }
+        ExecutionContextState::new()
     }
 
     fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -47,6 +47,10 @@ pub fn coerce(
     schema: &DFSchema,
     signature: &Signature,
 ) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+    if expressions.is_empty() {
+        return Ok(vec![]);
+    }
+
     let current_types = expressions
         .iter()
         .map(|e| e.data_type(schema))
@@ -69,6 +73,10 @@ pub fn data_types(
     current_types: &[DataType],
     signature: &Signature,
 ) -> Result<Vec<DataType>> {
+    if current_types.is_empty() {
+        return Ok(vec![]);
+    }
+
     let valid_types = get_valid_types(signature, current_types)?;
 
     if valid_types

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -1637,6 +1637,7 @@ pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
 mod tests {
     use super::*;
     use crate::datasource::empty::EmptyTable;
+    use crate::execution::context::ExecutionProps;
     use crate::optimizer::optimizer::OptimizerRule;
     use crate::optimizer::projection_push_down::ProjectionPushDown;
     use crate::{logical_plan::create_udf, sql::parser::DFParser};
@@ -2832,7 +2833,7 @@ mod tests {
 
     fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
         let rule = ProjectionPushDown::new();
-        rule.optimize(plan)
+        rule.optimize(plan, &ExecutionProps::new())
     }
 
     fn logical_plan(sql: &str) -> Result<LogicalPlan> {

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -2161,7 +2161,7 @@ macro_rules! test_expression {
         let mut ctx = ExecutionContext::new();
         let sql = format!("SELECT {}", $SQL);
         let actual = execute(&mut ctx, sql.as_str()).await;
-        assert_eq!($EXPECTED, actual[0][0]);
+        assert_eq!(actual[0][0], $EXPECTED);
     };
 }
 
@@ -2682,6 +2682,53 @@ async fn test_cast_expressions() -> Result<()> {
     test_expression!("CAST(NULL AS INT)", "NULL");
     test_expression!("TRY_CAST('0' AS INT)", "0");
     test_expression!("TRY_CAST('x' AS INT)", "NULL");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_current_timestamp_expressions() -> Result<()> {
+    let t1 = chrono::Utc::now().timestamp();
+    let mut ctx = ExecutionContext::new();
+    let actual = execute(&mut ctx, "SELECT NOW(), NOW() as t2").await;
+    let res1 = actual[0][0].as_str();
+    let res2 = actual[0][1].as_str();
+    let t3 = chrono::Utc::now().timestamp();
+    let t2_naive =
+        chrono::NaiveDateTime::parse_from_str(res1, "%Y-%m-%d %H:%M:%S%.6f").unwrap();
+
+    let t2 = t2_naive.timestamp();
+    assert!(t1 <= t2 && t2 <= t3);
+    assert_eq!(res2, res1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_current_timestamp_expressions_non_optimized() -> Result<()> {
+    let t1 = chrono::Utc::now().timestamp();
+    let ctx = ExecutionContext::new();
+    let sql = "SELECT NOW(), NOW() as t2";
+
+    let msg = format!("Creating logical plan for '{}'", sql);
+    let plan = ctx.create_logical_plan(sql).expect(&msg);
+
+    let msg = format!("Creating physical plan for '{}': {:?}", sql, plan);
+    let plan = ctx.create_physical_plan(&plan).expect(&msg);
+
+    let msg = format!("Executing physical plan for '{}': {:?}", sql, plan);
+    let res = collect(plan).await.expect(&msg);
+    let actual = result_vec(&res);
+
+    let res1 = actual[0][0].as_str();
+    let res2 = actual[0][1].as_str();
+    let t3 = chrono::Utc::now().timestamp();
+    let t2_naive =
+        chrono::NaiveDateTime::parse_from_str(res1, "%Y-%m-%d %H:%M:%S%.6f").unwrap();
+
+    let t2 = t2_naive.timestamp();
+    assert!(t1 <= t2 && t2 <= t3);
+    assert_eq!(res2, res1);
+
     Ok(())
 }
 

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -85,6 +85,7 @@ use std::task::{Context, Poll};
 use std::{any::Any, collections::BTreeMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
+use datafusion::execution::context::ExecutionProps;
 use datafusion::logical_plan::DFSchemaRef;
 
 /// Execute the specified sql and return the resulting record batches
@@ -211,7 +212,11 @@ impl QueryPlanner for TopKQueryPlanner {
 struct TopKOptimizerRule {}
 impl OptimizerRule for TopKOptimizerRule {
     // Example rewrite pass to insert a user defined LogicalPlanNode
-    fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+    fn optimize(
+        &self,
+        plan: &LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<LogicalPlan> {
         // Note: this code simply looks for the pattern of a Limit followed by a
         // Sort and replaces it by a TopK node. It does not handle many
         // edge cases (e.g multiple sort columns, sort ASC / DESC), etc.
@@ -226,7 +231,7 @@ impl OptimizerRule for TopKOptimizerRule {
                     return Ok(LogicalPlan::Extension {
                         node: Arc::new(TopKPlanNode {
                             k: *n,
-                            input: self.optimize(input.as_ref())?,
+                            input: self.optimize(input.as_ref(), execution_props)?,
                             expr: expr[0].clone(),
                         }),
                     });
@@ -236,7 +241,7 @@ impl OptimizerRule for TopKOptimizerRule {
 
         // If we didn't find the Limit/Sort combination, recurse as
         // normal and build the result.
-        optimize_children(self, plan)
+        optimize_children(self, plan, execution_props)
     }
 
     fn name(&self) -> &str {


### PR DESCRIPTION
* Add initial implementation of NOW

* Run rustfmt

* Change incorrect condition

* Add timestamp optimizer which optimizes the logical plan and makes sure all now() return same value

* Add unit tests & fix alias

* Add unit tests & fix alias

* Run cargo fmt

* Comment out failing test

* Optimize the match to fix clippy

* Initialize datetime during optimize not creation

* Add assertion to compare multiple now() values

* Run cargo fmt

* Move timestamp to execution props

* Add missing prop

* Add missing prop

* Remove duplicated code

* Fix tests & format

* Fix clippy

* Revert clippy fix

* Update datafusion/src/execution/context.rs

Co-authored-by: Andrew Lamb <andrew@nerdnetworks.org>

* Fix review comments. Move timestamp evaluation logic to constant_folding.rs

* Pass ExecutionProps to scalar functions

* Revert "Pass ExecutionProps to scalar functions"

This reverts commit d9cb005df4a4c1bf05b18b5d9a1aefc4f9e706bb.

* Add closure approach from @alamb

* Re-enable concat test

* Changing Option<DateTime<Utc>> to DateTime<Utc>

Co-authored-by: Sathis Kumar <sathis.kumar@udemy.com>
Co-authored-by: Andrew Lamb <andrew@nerdnetworks.org>