### PR TITLE
Disable failing GitHub action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,6 +60,7 @@ jobs:
   release:
     name: Source Release and Merge Script
     runs-on: ubuntu-20.04
+    if: false # Disabled in CubeStore fork
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
       GIT_AUTHOR_NAME: Github Actions

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,6 +52,7 @@ jobs:
 
   docker:
     name: AMD64 Conda Integration Test
+    if: false # Disabled in CubeStore fork.
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60


### PR DESCRIPTION
The Conda integration test has always been failing on CubeStore fork.